### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/preview-pulumi.yml
+++ b/.github/workflows/preview-pulumi.yml
@@ -2,6 +2,8 @@ name: Preview cirius-go/portfolio-frontend/dev
 on:
   pull_request:
     types: [opened,edited,reopened,synchronize]
+permissions:
+  contents: read
 env:
   ESC_ACTION_CLOUD_URL: https://api.pulumi.com
   ESC_ACTION_OIDC_ORGANZATION: cirius-go


### PR DESCRIPTION
Potential fix for [https://github.com/cirius-go/portfolio/security/code-scanning/2](https://github.com/cirius-go/portfolio/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow primarily involves checking out code, setting up Node.js, and running Pulumi commands, it likely only requires `contents: read` permissions. We will add this block at the workflow level to apply it to all jobs, ensuring minimal permissions are granted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
